### PR TITLE
enhancement: 커스텀 버튼 사이즈 선택 기능 추가

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -6,9 +6,7 @@ Button.propTypes = {
   type: PropTypes.string,
   onClick: PropTypes.func,
   color: PropTypes.string,
-  width: PropTypes.string,
-  height: PropTypes.string,
-  fontSize: PropTypes.number,
+  isBig: PropTypes.bool,
 };
 
 export default function Button({
@@ -16,17 +14,24 @@ export default function Button({
   type = "button",
   onClick: clickHandler,
   color = "#72BF78",
-  fontSize = 12,
+  isBig = false,
 }) {
   // 동적인 클래스는 style 객체 활용
   const style = {
     backgroundColor: color,
-    fontSize: fontSize,
   };
+
+  const baseClasses =
+    "flex items-center justify-center rounded-md shrink-0 text-white";
+  const sizeClasses = isBig
+    ? "w-full py-3 text-xl font-bold"
+    : "py-1 px-3 text-sm font-semibold";
+
+  const classes = clsx(baseClasses, sizeClasses);
 
   return (
     <button
-      className="flex text-center items-center rounded-md shrink-0 text-white font-semibold px-3 py-1"
+      className={classes}
       style={style}
       type={type}
       onClick={clickHandler}

--- a/src/pages/market/CartPage.jsx
+++ b/src/pages/market/CartPage.jsx
@@ -206,12 +206,9 @@ export default function CartPage() {
                 showButton ? "bottom-0 opacity-100" : "-bottom-24 opacity-0"
               )}
             >
-              <button
-                className="bg-btn-primary py-3 w-full text-white text-xl font-bold rounded-lg"
-                type="submit"
-              >
+              <Button isBig={true} type="submit">
                 {DUMMY_CARTS_ITEMS.cost.total.toLocaleString()}원 구매하기
-              </button>
+              </Button>
             </section>
           </form>
         </>

--- a/src/pages/market/PaymentPage.jsx
+++ b/src/pages/market/PaymentPage.jsx
@@ -354,12 +354,9 @@ export default function PaymentPage() {
           showButton ? "bottom-0 opacity-100" : "-bottom-24 opacity-0"
         )}
       >
-        <button
-          className="bg-btn-primary py-3 w-full text-white text-xl font-bold rounded-lg"
-          onClick={openModal}
-        >
+        <Button isBig={true} onClick={openModal}>
           {DUMMY_CARTS_ITEMS.cost.total.toLocaleString()}원 결제하기
-        </button>
+        </Button>
       </section>
     </>
   );


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- props로 받는 항목 최소화 (폰트 사이즈 삭제)
- 큰 버튼을 사용하려면 props로 `isBig = {true}` 를 전달해주면 됩니다. 기본값은 `isBig = false` 이므로 작은 버튼 사용시에는 아무것도 전달할 필요 없음.
- 작은 버튼 예시
<img width="326" alt="image" src="https://github.com/user-attachments/assets/68857710-b0fa-4992-9663-969398ac3f8b" />
<img width="319" alt="image" src="https://github.com/user-attachments/assets/a7393bae-3a0d-4476-9dd2-df73685a37e0" />

- 큰 버튼 예시
<img width="393" alt="image" src="https://github.com/user-attachments/assets/d0992489-15cd-4f2d-8d72-36277f5073a0" />


## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #98 
